### PR TITLE
Task failure checks

### DIFF
--- a/disBatch.py
+++ b/disBatch.py
@@ -166,7 +166,7 @@ class BatchContext(object):
         '''Called when a node has exited.  May be overridden to release resources.'''
         if ret: self.error = True
         if self.retireCmd:
-            logger.info('Retiring node "%s" with command', node)
+            logger.info('Retiring node "%s" with command %s', node, str(retireCmd))
             env = self.retireEnv(node, ret)
             try:
                 SUB.check_call(self.retireCmd, close_fds=True, shell=True, env=env)

--- a/disBatch.py
+++ b/disBatch.py
@@ -470,7 +470,13 @@ def taskGenerator(tasks, context):
                     continue
                 m = dbbarrier.match(t)
                 if m:
-                    yield BarrierTask(taskCounter, tsx, -1, t, m.group(1))
+                    bkey = m.group(1)
+                    if bkey == 'CHECK':
+                        check = True
+                        bkey = None
+                    else:
+                        check = False
+                    yield BarrierTask(taskCounter, tsx, -1, t, key=bkey, check=check)
                     taskCounter += 1
                     continue
                 logger.error('Unknown #DISBATCH directive: %s', t)

--- a/disBatch.py
+++ b/disBatch.py
@@ -1100,3 +1100,6 @@ if '__main__' == __name__:
             print('Some engine processes failed -- please check the logs', file=sys.stderr)
             sys.exit(1)
 
+        if f.failed:
+            print('Some tasks failed with non-zero exit codes -- please check the logs', file=sys.stderr)
+            sys.exit(1)


### PR DESCRIPTION
First of all, thanks for developing this great package!  There were a few small features I needed for my use-case, so I hacked them into the code, probably in a sub-optimal way.  But maybe they could make their way into master with some expert advice.

First, I had a non-disBatch SLURM job that I wanted to trigger after successful completion of multiple disBatch jobs, so I was going to use SLURM dependencies with the "afterok" condition.  So I needed disBatch to return a non-zero exit code if any task failed.  It seemed that disBatch was already counting task failures, so I just added a `sys.exit(1)` at the end if a failure was counted.

Separately, I also had a `#DISBATCH BARRIER` that I only wanted to pass if all previous tasks succeeded.  There was already a "check barrier" mechanism in the Python, so I added a `#DISBATCH BARRIER CHECK` option to trigger that.  I think it means that `CHECK` is no longer a valid key to `BARRIER`, so my guess is that a different syntax would be preferred.  Happy to take suggestions.