### PR TITLE
Fix output capture for Python 3.6

### DIFF
--- a/disbatch/disBatch.py
+++ b/disbatch/disBatch.py
@@ -313,7 +313,7 @@ class SlurmContext(BatchContext):
         if args.tasksPerNode != -1:
             self.tasksPerNode = args.tasksPerNode
             if sntpn:
-                self.for_log.append((f'Argument tasksPerNode is set to {self.tasksPerNode}, ignoring SLURM_NTASKS_PER_NODE ({sntpn})', self.INFO))
+                self.for_log.append((f'Argument tasksPerNode is set to {self.tasksPerNode}, ignoring SLURM_NTASKS_PER_NODE ({sntpn})', logging.INFO))
                 if self.tasksPerNode != sntpn:
                     self.for_log.append((f'disBatch argument tasksPerNode ({self.tasksPerNode}) conflicts with SLURM_NTASKS_PER_NODE ({sntpn}). Using disBatch value.', self.USERWARNING))
         elif sntpn:

--- a/disbatch/disBatch.py
+++ b/disbatch/disBatch.py
@@ -214,7 +214,7 @@ class BatchContext:
             env = self.retireEnv(node, ret)
             try:
                 capture = SUB.run(self.retireCmd, close_fds=True, shell=True, env=env,
-                                  check=True, capture_output=True)
+                                  check=True, stdout=SUB.PIPE, stderr=SUB.PIPE)
             except Exception as e:
                 logger.warning('Retirement planning needs improvement: %s', repr(e))
                 capture = e


### PR DESCRIPTION
As far as I can tell, `stdout=SUB.PIPE, stderr=SUB.PIPE` is exactly equivalent to `capture_output=True`, so this a pretty straightforward change.  I tested on Python 3.6 and 3.9.

Also fixes a typo in one of the log levels.