### PR TITLE
Add basic tests. Run the ssh-mode test on GitHub Actions.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,30 @@
+name: Run basic tests
+
+on: [push]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+
+        with:
+          python-version: ${{ matrix.python-version }}
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ./
+          
+      - name: Run local-mode (ssh) test
+        run: |
+          cd tests/test_ssh
+          bash run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /exampleTaskFiles/slurm*resize.*sh
 /exampleTaskFiles/dbTestOutputDir
 /tmp
+/tests/test_*/disbatch-test.*
+__pycache__/
+*.egg-info/

--- a/disBatch
+++ b/disBatch
@@ -5,7 +5,7 @@ try:
 except Exception as e:
     import os, sys
     pp = os.environ.get('PYTHONPATH', '<Not Set>')
-    print(f'Unable to import disBatch. Check:\n\tPYTHONPATH {pp!r}. '
+    print(f'Unable to import disBatch. Check:\n\tPYTHONPATH {pp!r}.\n'
            'Original exception follows.', file=sys.stderr)
     raise e
 

--- a/disBatch
+++ b/disBatch
@@ -2,10 +2,11 @@
 
 try:
     from disbatch import disBatch
-except:
+except Exception as e:
     import os, sys
     pp = os.environ.get('PYTHONPATH', '<Not Set>')
-    print(f'disBatch environment is incomplete. Check:\n\tPYTHONPATH {pp!r}.', file=sys.stderr)
-    sys.exit(1)
+    print(f'Unable to import disBatch. Check:\n\tPYTHONPATH {pp!r}. '
+           'Original exception follows.', file=sys.stderr)
+    raise e
 
 disBatch.main()

--- a/tests/test_slurm/Tasks
+++ b/tests/test_slurm/Tasks
@@ -1,0 +1,3 @@
+touch A.txt
+touch B.txt
+touch C.txt

--- a/tests/test_slurm/run.sh
+++ b/tests/test_slurm/run.sh
@@ -12,10 +12,13 @@ salloc -n 2 disBatch Tasks
 [[ -f A.txt && -f B.txt && -f C.txt ]]
 success=$?
 
+cd -
+
 if [[ $success -eq 0 ]]; then
     echo "Slurm test passed."
+    rm -rf $workdir
 else
-    echo "Slurm test failed!"
+    echo "Slurm test failed! Output is in $workdir"
 fi
 
 exit $success

--- a/tests/test_slurm/run.sh
+++ b/tests/test_slurm/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/bash
+
+workdir=$(mktemp -d -p ./ disbatch-test.XXXX)
+cp Tasks $workdir
+cd $workdir
+
+# Run the test
+salloc -n 2 disBatch Tasks
+
+# Check that all 3 tasks ran,
+# which means A.txt, B.txt, and C.txt exist
+[[ -f A.txt && -f B.txt && -f C.txt ]]
+success=$?
+
+if [[ $success -eq 0 ]]; then
+    echo "Slurm test passed."
+else
+    echo "Slurm test failed!"
+fi
+
+exit $success

--- a/tests/test_ssh/Tasks
+++ b/tests/test_ssh/Tasks
@@ -1,0 +1,3 @@
+touch A.txt
+touch B.txt
+touch C.txt

--- a/tests/test_ssh/run.sh
+++ b/tests/test_ssh/run.sh
@@ -12,10 +12,13 @@ disBatch -s localhost:2 Tasks
 [[ -f A.txt && -f B.txt && -f C.txt ]]
 success=$?
 
+cd -
+
 if [[ $success -eq 0 ]]; then
     echo "SSH test passed."
+    rm -rf $workdir
 else
-    echo "SSH test failed!"
+    echo "SSH test failed! Output is in $workdir"
 fi
 
 exit $success

--- a/tests/test_ssh/run.sh
+++ b/tests/test_ssh/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/bash
+
+workdir=$(mktemp -d -p ./ disbatch-test.XXXX)
+cp Tasks $workdir
+cd $workdir
+
+# Run the test
+disBatch -s localhost:2 Tasks
+
+# Check that all 3 tasks ran,
+# which means A.txt, B.txt, and C.txt exist
+[[ -f A.txt && -f B.txt && -f C.txt ]]
+success=$?
+
+if [[ $success -eq 0 ]]; then
+    echo "SSH test passed."
+else
+    echo "SSH test failed!"
+fi
+
+exit $success


### PR DESCRIPTION
This PR adds a basic test, which touches some files then checks that those files exist.  There are two copies of this test: one for ssh mode, and one for Slurm.  While for now the only thing different about the tests is the disBatch invocation, I've kept them separate because we might want to add more functionality to the Slurm test in the future.  The ssh-mode is tested on GitHub Actions for Python versions 3.6 to 3.10.

The Slurm test can only be run locally for now, but in theory it would be possible to set up a GitHub Action that installs Slurm and runs the test.