### PR TITLE
Fix Python 3.6 GitHub tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Run basic tests
+name: Tests
 
 on: [push]
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,8 @@
 Distributed processing of a batch of tasks.
 ===========================================
 
+[![Tests](https://github.com/flatironinstitute/disBatch/actions/workflows/tests.yaml/badge.svg)](https://github.com/flatironinstitute/disBatch/actions/workflows/tests.yaml)
+
 ## TL;DR
 
 Create a file `Tasks`:

--- a/tests/test_slurm/run.sh
+++ b/tests/test_slurm/run.sh
@@ -12,7 +12,7 @@ salloc -n 2 disBatch Tasks
 [[ -f A.txt && -f B.txt && -f C.txt ]]
 success=$?
 
-cd -
+cd - > /dev/null
 
 if [[ $success -eq 0 ]]; then
     echo "Slurm test passed."

--- a/tests/test_ssh/run.sh
+++ b/tests/test_ssh/run.sh
@@ -12,7 +12,7 @@ disBatch -s localhost:2 Tasks
 [[ -f A.txt && -f B.txt && -f C.txt ]]
 success=$?
 
-cd -
+cd - > /dev/null
 
 if [[ $success -eq 0 ]]; then
     echo "SSH test passed."


### PR DESCRIPTION
We got caught in the middle of a transition of the `ubuntu-latest` tag from 20.04 to 22.04, which doesn't support Python 3.6.  So we'll pin to 20.04.

Also adds a test status badge to the readme.