### PR TITLE
Make `SLURM_CPU_BIND=cores` the default

### DIFF
--- a/disbatch/disBatch.py
+++ b/disbatch/disBatch.py
@@ -334,9 +334,9 @@ class SlurmContext(BatchContext):
         scpt = os.environ.get('SLURM_CPUS_PER_TASK')
         if args.cpusPerTask != -1.0:
             self.cpusPerTask = args.cpusPerTask
-            cores_per_cylinder = [args.cpusPerTask]*len(nodes)
+            cores_per_cylinder = [int(args.cpusPerTask)]*len(nodes)
             if scpt:
-                if self.cpusPerTask != scpt:
+                if self.cpusPerTask != int(scpt):
                     self.for_log.append((f'disBatch argument cpusPerTask ({self.cpusPerTask}) conflicts with SLURM_CPUS_PER_TASK ({scpt}). Using disBatch value.', self.USERWARNING))
         else:
             self.cpusPerTask = int(scpt) if scpt else 1
@@ -347,7 +347,7 @@ class SlurmContext(BatchContext):
             self.tasksPerNode = args.tasksPerNode
             if sntpn:
                 self.for_log.append((f'Argument tasksPerNode is set to {self.tasksPerNode}, ignoring SLURM_NTASKS_PER_NODE ({sntpn})', logging.INFO))
-                if self.tasksPerNode != sntpn:
+                if self.tasksPerNode != int(sntpn):
                     self.for_log.append((f'disBatch argument tasksPerNode ({self.tasksPerNode}) conflicts with SLURM_NTASKS_PER_NODE ({sntpn}). Using disBatch value.', self.USERWARNING))
         elif sntpn:
             self.tasksPerNode = int(sntpn)
@@ -482,7 +482,8 @@ class SlurmContext(BatchContext):
             logging.warning(f'SLURM believes tasks should be {self.stpnl[nx]}, attempting to run {tasks}.')
         # srun the appropriate number of task servers for this node. 0-rank will fork off the engine proper.
         # The logic for this is in SlurmContext.engine_start.
-        cmd = ['srun', '-N', '1', '-n', str(tasks), '-c', '%d'%self.cores_per_cylinder[nx], '-w', n, 'bash', '-c', f'{DbUtilPath} --engine -n {n} --method SlurmContext.engine {self.kvsKey} --tag slurm_context_engine_{int(10e7*random.random())}']
+        # SLURM_CPU_BIND is set in the environment, since the user might want to override that
+        cmd = ['srun', '-N', '1', '-n', str(tasks), '-c', str(self.cores_per_cylinder[nx]), '-w', n, 'bash', '-c', f'{DbUtilPath} --engine -n {n} --method SlurmContext.engine {self.kvsKey} --tag slurm_context_engine_{int(10e7*random.random())}']
         logging.info('launch cmd: %s', repr(cmd))
         return SUB.Popen(cmd, stdout=open(lfp, 'w'), stderr=SUB.STDOUT, close_fds=True)
 
@@ -608,7 +609,7 @@ class SSHContext(BatchContext):
         else:
             cylinders = [int(cc//self.cpusPerTask) for cc in core_count]
             self.for_log.append((f'Tasks per node: {cylinders}, using {self.cpusPerTask} cores per task.', logging.INFO))
-        cores_per_cylinder = [cc/c if c else cc for cc, c in zip(core_count, cylinders)]
+        cores_per_cylinder = [cc//c if c else cc for cc, c in zip(core_count, cylinders)]
         super(SSHContext, self).__init__('SSH', dbInfo, rank, nodes, cylinders, cores_per_cylinder, args, contextLabel)
 
     def launchNode(self, n):

--- a/disbatch/disBatch.py
+++ b/disbatch/disBatch.py
@@ -373,13 +373,17 @@ class SlurmContext(BatchContext):
                 cylinders = [min(stpn, int(jcpn//self.cpusPerTask)) for stpn, jcpn in zip(self.stpnl, jcpnl)]
                 self.for_log.append((f'Tasks per node: {self.stpnl} -> {cylinders}, using {self.cpusPerTask} cores per task.', logging.INFO))
         if cores_per_cylinder is None:
-            cores_per_cylinder = [jcpn/c if c else jcpn for jcpn, c in zip(jcpnl, cylinders)]
+            cores_per_cylinder = [jcpn//c if c else jcpn for jcpn, c in zip(jcpnl, cylinders)]
         
         # Provide a hook to allow the user to alter srun options.
         opt_file = os.environ.get('DISBATCH_SLURM_SRUN_OPTIONS_FILE', None)
+        opts = []
         if opt_file:
             self.for_log.append(('Taking srun options from "%s".'%opt_file, logging.INFO))
             opts = open(opt_file).read().split('\n')
+        else:
+            opts = ['SLURM_CPU_BIND=' + os.getenv('SLURM_CPU_BIND', 'cores')]
+        if opts:
             self.for_log.append(('Adding srun options:', logging.INFO))
             for l in opts:
                 if l:

--- a/disbatch/disBatch.py
+++ b/disbatch/disBatch.py
@@ -1436,7 +1436,7 @@ class EngineBlock(Thread):
             for v, l in envres.items():
                 try:
                     self.localEnv[v] = l[0 if -1 == cylinderRank else cylinderRank] # Allow the per engine cylinder to access cylinder
-                    	                                                            # 0's resources. TODO: Ensure some sort of lock?
+                                                                                    # 0's resources. TODO: Ensure some sort of lock?
                 except IndexError:
                     # safer to set it empty than delete it for most cases
                     self.localEnv[v] = ''


### PR DESCRIPTION
The main change here is to turn on CPU binding by default. For multi-threaded tasks, this will make most thread pools (like OpenMP) spawn the right number of threads.

Note that disBatch effectively treats the sbatch value of `-c` as a minimum number of cores per task. So the following will result in 64 cores per task on a 128 core node:

`salloc -n2 -c2 --exclusive disBatch tasks`

One can pass `-c2` to disBatch again to get 2 cores per task:

`salloc -n2 -c2 --exclusive disBatch -c2 tasks`

This is probably all fine and working as intended; users typically don't have an upper limit on the number of threads per task.